### PR TITLE
ArtPaint: update calls to get cpu count/speed instead of legacy BeOS …

### DIFF
--- a/addons/AddOns/Working/BlurAddOn/Blur.cpp
+++ b/addons/AddOns/Working/BlurAddOn/Blur.cpp
@@ -136,9 +136,7 @@ int32 BlurManipulator::PreviewBitmap(Selection *sel, bool full_quality,BRegion *
 	if ((settings == previous_settings) == FALSE) {
 		// The blur will be done separably. First in the vertical direction and then in horizontal
 		// direction.
-		system_info info;
-		get_system_info(&info);
-		thread_count = info.cpu_count;
+		thread_count = GetSystemCpuCount();
 		tall_bits = (uint32*)tall_copy_of_the_preview_bitmap->Bits();
 		wide_bits = (uint32*)wide_copy_of_the_preview_bitmap->Bits();
 		final_bits = (uint32*)preview_bitmap->Bits();

--- a/addons/AddOns/Working/Brightness/Brightness.cpp
+++ b/addons/AddOns/Working/Brightness/Brightness.cpp
@@ -18,7 +18,7 @@
 #include "Brightness.h"
 #include "ManipulatorInformer.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -128,9 +128,7 @@ int32 BrightnessManipulator::PreviewBitmap(Selection *selection,bool full_qualit
 
 void BrightnessManipulator::start_threads()
 {
-	system_info info;
-	get_system_info(&info);
-	number_of_threads = info.cpu_count;
+	number_of_threads = GetSystemCpuCount();
 
 	thread_id *threads = new thread_id[number_of_threads];
 
@@ -302,14 +300,10 @@ void BrightnessManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-
 		// Let's select a resolution that can handle all the pixels at least
 		// 10 times in a second while assuming that one pixel calculation takes
 		// about 50 CPU cycles.
-		speed = speed / (10*50);
+		double speed = GetSystemClockSpeed() / (10*50);
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;

--- a/addons/AddOns/Working/Contrast/Contrast.cpp
+++ b/addons/AddOns/Working/Contrast/Contrast.cpp
@@ -18,7 +18,7 @@
 #include "Contrast.h"
 #include "ManipulatorInformer.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -153,9 +153,7 @@ uint8 ContrastManipulator::CalculateAverageLuminance(BBitmap *bitmap)
 
 void ContrastManipulator::start_threads()
 {
-	system_info info;
-	get_system_info(&info);
-	number_of_threads = info.cpu_count;
+	number_of_threads = GetSystemCpuCount();
 
 	thread_id *threads = new thread_id[number_of_threads];
 
@@ -325,14 +323,10 @@ void ContrastManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-
 		// Let's select a resolution that can handle all the pixels at least
 		// 10 times in a second while assuming that one pixel calculation takes
 		// about 50 CPU cycles.
-		speed = speed / (10*50);
+		double speed = GetSystemClockSpeed() / (10*50);
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;
@@ -423,7 +417,7 @@ ContrastManipulatorView::ContrastManipulatorView(ContrastManipulator *manip,
 	BLayoutBuilder::Group<>(this, B_VERTICAL)
 		.Add(contrast_slider)
 		.SetInsets(B_USE_SMALL_INSETS)
-		.End();	
+		.End();
 }
 
 ContrastManipulatorView::~ContrastManipulatorView()

--- a/addons/AddOns/Working/EdgeDetector/DetectEdges.h
+++ b/addons/AddOns/Working/EdgeDetector/DetectEdges.h
@@ -19,6 +19,7 @@ class DetectEdgesManipulator : public Manipulator {
 
 static	int32		thread_entry(void*);
 		int32		thread_function(int32);
+		int			processor_count;
 
 public:
 			DetectEdgesManipulator();

--- a/addons/AddOns/Working/EnhanceEdges/EnhanceEdges.cpp
+++ b/addons/AddOns/Working/EnhanceEdges/EnhanceEdges.cpp
@@ -39,6 +39,7 @@ Manipulator* instantiate_add_on(BBitmap*,ManipulatorInformer *i)
 EnhanceEdgesManipulator::EnhanceEdgesManipulator()
 		: Manipulator()
 {
+	processor_count = GetSystemCpuCount();
 }
 
 
@@ -84,21 +85,18 @@ BBitmap* EnhanceEdgesManipulator::ManipulateBitmap(BBitmap *original,Selection *
 	the_selection = selection;
 	progress_bar = status_bar;
 
-	system_info info;
-	get_system_info(&info);
-
-	thread_id *threads = new thread_id[info.cpu_count];
+	thread_id *threads = new thread_id[processor_count];
 
 	// Start the threads. If the image is small enough
 	// one thread might be enough.
-	for (int32 i=0;i<info.cpu_count;i++) {
+	for (int32 i = 0;i < processor_count;i++) {
 		threads[i] = spawn_thread(thread_entry,"enhance_edges_thread",B_NORMAL_PRIORITY,this);
 		resume_thread(threads[i]);
 		send_data(threads[i],i,NULL,0);
 	}
 
 	// Wait for them threads to finish.
-	for (int32 i=0;i<info.cpu_count;i++) {
+	for (int32 i = 0;i < processor_count;i++) {
 		int32 return_value;
 		wait_for_thread(threads[i],&return_value);
 	}
@@ -155,15 +153,12 @@ int32 EnhanceEdgesManipulator::thread_function(int32 thread_number)
 		int32 top = target_bitmap->Bounds().top;
 		int32 bottom = target_bitmap->Bounds().bottom;
 
-		system_info info;
-		get_system_info(&info);
-
 		float height = bottom - top;
-		top = height/info.cpu_count*thread_number;
-		bottom = min_c(bottom,top + (height+1)/info.cpu_count);
+		top = height/processor_count*thread_number;
+		bottom = min_c(bottom,top + (height+1)/processor_count);
 
 		int32 update_interval = 10;
-		float update_amount = 100.0/(bottom-top)*update_interval/(float)info.cpu_count;
+		float update_amount = 100.0/(bottom-top)*update_interval/(float)processor_count;
 		float missed_update = 0;
 
 		target += top*target_bpr;
@@ -258,15 +253,12 @@ int32 EnhanceEdgesManipulator::thread_function(int32 thread_number)
 		int32 top = rect.top;
 		int32 bottom = rect.bottom;
 
-		system_info info;
-		get_system_info(&info);
-
 		float height = bottom - top;
-		top += height/info.cpu_count*thread_number;
-		bottom = min_c(bottom,top + (height+1)/info.cpu_count);
+		top += height/processor_count*thread_number;
+		bottom = min_c(bottom,top + (height+1)/processor_count);
 
 		int32 update_interval = 10;
-		float update_amount = 100.0/(bottom-top)*update_interval/(float)info.cpu_count;
+		float update_amount = 100.0/(bottom-top)*update_interval/(float)processor_count;
 
 		// Loop through all pixels in original.
 		for (int32 y=top;y<=bottom;++y) {

--- a/addons/AddOns/Working/EnhanceEdges/EnhanceEdges.h
+++ b/addons/AddOns/Working/EnhanceEdges/EnhanceEdges.h
@@ -19,6 +19,7 @@ class EnhanceEdgesManipulator : public Manipulator {
 
 static	int32		thread_entry(void*);
 		int32		thread_function(int32);
+		int			processor_count;
 
 public:
 			EnhanceEdgesManipulator();

--- a/addons/AddOns/Working/GaussianBlur/GaussianBlur.cpp
+++ b/addons/AddOns/Working/GaussianBlur/GaussianBlur.cpp
@@ -20,7 +20,6 @@
 #include "GaussianBlur.h"
 #include "ImageProcessingLibrary.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
 
 
 #ifdef __cplusplus
@@ -53,9 +52,7 @@ GaussianBlurManipulator::GaussianBlurManipulator(BBitmap *bm)
 
 	previous_settings.blur = settings.blur + 1;
 
-	system_info info;
-	get_system_info(&info);
-	processor_count = info.cpu_count;
+	processor_count = GetSystemCpuCount();
 
 	ipLibrary = new ImageProcessingLibrary();
 
@@ -198,24 +195,20 @@ void GaussianBlurManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-
 		// Let's select a resolution that can handle all the pixels at least
 		// 10 times in a second while assuming that one pixel calculation takes
 		// about 50 CPU cycles.
-		speed = speed / (10*50);
+		double speed = GetSystemClockSpeed() / (10*50);
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;
+
 		while ((num_pixels/lowest_available_quality/lowest_available_quality) > speed)
 			lowest_available_quality *= 2;
 
 		lowest_available_quality = min_c(lowest_available_quality,16);
 		highest_available_quality = max_c(lowest_available_quality/2,1);
-	}
-	else {
+	} else {
 		lowest_available_quality = 1;
 		highest_available_quality = 1;
 	}

--- a/addons/AddOns/Working/Interference/Interference.cpp
+++ b/addons/AddOns/Working/Interference/Interference.cpp
@@ -17,7 +17,6 @@
 #include "Interference.h"
 #include "PixelOperations.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
 
 #define PI M_PI
 
@@ -186,10 +185,7 @@ void InterferenceManipulator::SetPreviewBitmap(BBitmap *bm)
 		}
 	}
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-		speed = speed / 15000;
+		double speed = GetSystemClockSpeed() / 15000;
 
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);

--- a/addons/AddOns/Working/MarbleTexturer/Marble.h
+++ b/addons/AddOns/Working/MarbleTexturer/Marble.h
@@ -27,6 +27,7 @@ static	int32		thread_entry(void*);
 		int32		thread_function(int32);
 
 		float		marble_amount(float);
+		int			processor_count;
 
 public:
 			MarbleManipulator(ManipulatorInformer*);

--- a/addons/AddOns/Working/Saturation/Saturation.cpp
+++ b/addons/AddOns/Working/Saturation/Saturation.cpp
@@ -17,7 +17,7 @@
 #include "ManipulatorInformer.h"
 #include "Saturation.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -162,9 +162,7 @@ int32 SaturationManipulator::PreviewBitmap(Selection *selection,bool full_qualit
 
 void SaturationManipulator::start_threads()
 {
-	system_info info;
-	get_system_info(&info);
-	number_of_threads = info.cpu_count;
+	number_of_threads = GetSystemCpuCount();
 
 	thread_id *threads = new thread_id[number_of_threads];
 
@@ -341,14 +339,10 @@ void SaturationManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-
 		// Let's select a resolution that can handle all the pixels at least
 		// 10 times in a second while assuming that one pixel calculation takes
 		// about 50 CPU cycles.
-		speed = speed / (10*50);
+		double speed = GetSystemClockSpeed() / (10*50);
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;

--- a/addons/AddOns/Working/Sharpness/Sharpness.cpp
+++ b/addons/AddOns/Working/Sharpness/Sharpness.cpp
@@ -19,7 +19,7 @@
 #include "Sharpness.h"
 #include "ImageProcessingLibrary.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
+
 
 #ifdef __cplusplus
 extern "C" {
@@ -50,9 +50,7 @@ SharpnessManipulator::SharpnessManipulator(BBitmap *bm)
 
 	previous_settings.sharpness = settings.sharpness + 1;
 
-	system_info info;
-	get_system_info(&info);
-	processor_count = info.cpu_count;
+	processor_count = GetSystemCpuCount();
 
 	ipLibrary = new ImageProcessingLibrary();
 
@@ -324,14 +322,10 @@ void SharpnessManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-
 		// Let's select a resolution that can handle all the pixels at least
 		// 10 times in a second while assuming that one pixel calculation takes
 		// about 50 CPU cycles.
-		speed = speed / (10*50);
+		double speed = GetSystemClockSpeed() / (10*50);
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;

--- a/addons/AddOns/Working/Threshold/Threshold.cpp
+++ b/addons/AddOns/Working/Threshold/Threshold.cpp
@@ -25,7 +25,6 @@
 #include "Selection.h"
 #include "Threshold.h"
 #include "ThresholdView.h"
-#include "SysInfoBeOS.h"
 
 
 #ifdef __cplusplus
@@ -141,9 +140,7 @@ int32 ThresholdManipulator::PreviewBitmap(Selection *selection,bool full_quality
 
 void ThresholdManipulator::start_threads()
 {
-	system_info info;
-	get_system_info(&info);
-	number_of_threads = info.cpu_count;
+	number_of_threads = GetSystemCpuCount();
 
 	thread_id *threads = new thread_id[number_of_threads];
 
@@ -328,14 +325,10 @@ void ThresholdManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-
 		// Let's select a resolution that can handle all the pixels at least
 		// 10 times in a second while assuming that one pixel calculation takes
 		// about 50 CPU cycles.
-		speed = speed / (10*50);
+		double speed = GetSystemClockSpeed() / (10*50);
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;

--- a/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
+++ b/addons/AddOns/Working/TwirlAddOn/Twirl.cpp
@@ -20,7 +20,6 @@
 #include "Twirl.h"
 #include "PixelOperations.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
 
 
 #ifdef __cplusplus
@@ -431,10 +430,7 @@ void TwirlManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-		speed = speed / 10000;
+		double speed = GetSystemClockSpeed() / 10000;
 
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);

--- a/addons/AddOns/Working/WaveAddOn/Wave.cpp
+++ b/addons/AddOns/Working/WaveAddOn/Wave.cpp
@@ -19,7 +19,6 @@
 #include "Wave.h"
 #include "PixelOperations.h"
 #include "Selection.h"
-#include "SysInfoBeOS.h"
 
 #define PI M_PI
 
@@ -897,10 +896,7 @@ void WaveManipulator::SetPreviewBitmap(BBitmap *bm)
 		}
 	}
 	if (preview_bitmap != NULL) {
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-		speed = speed / 15000;
+		double speed = GetSystemClockSpeed() / 15000;
 
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);

--- a/addons/AddOns/Working/WoodRelief/Wood.h
+++ b/addons/AddOns/Working/WoodRelief/Wood.h
@@ -21,6 +21,7 @@ class WoodManipulator : public Manipulator {
 
 static	int32		thread_entry(void*);
 		int32		thread_function(int32);
+		int			processor_count;
 
 public:
 			WoodManipulator();

--- a/artpaint/application/PixelOperations.h
+++ b/artpaint/application/PixelOperations.h
@@ -18,14 +18,6 @@ union color_conversion_union {
 	uint32 word;
 };
 
-// This is just an utility-function for rounding the values.
-// It can be made faster by using inline assebler code. Especially
-// instructions frsp and fctlw could be useful on the PPC.
-inline float round(float c)
-{
-	return (((c - floor(c)) > 0.5) ? ceil(c) : floor(c));
-}
-
 
 // This function combines four pixels p1-p4 with weights c1-c4.
 // It accumulates the rounding error for each component and

--- a/artpaint/layers/Layer.cpp
+++ b/artpaint/layers/Layer.cpp
@@ -72,10 +72,7 @@ Layer::Layer(BRect frame, int32 id, ImageView* imageView, layer_type type,
 			*target_bits++ = color.word;
 
 		if (bitmap && bitmap->IsValid()) {
-			// "width" and "height" in ImportBits are pixel counts!:
-			fLayerData->ImportBits(bitmap, B_ORIGIN, B_ORIGIN,
-				int32(min_c(frame.Width(), sourceRect.Width()))+1,
-				int32(min_c(frame.Height(), sourceRect.Height()))+1);
+			fLayerData->ImportBits(bitmap);
 		}
 
 		// create the miniature image for this layer and a semaphore for it

--- a/artpaint/viewmanipulators/Manipulator.cpp
+++ b/artpaint/viewmanipulators/Manipulator.cpp
@@ -17,6 +17,34 @@
 #include <stdlib.h>
 
 
+Manipulator::Manipulator()
+{
+	add_on_id = -1;
+	fSystemClockSpeed = 0;
+
+	system_info info;
+	get_system_info(&info);
+	fCpuCount = info.cpu_count;
+	fSystemClockSpeed = 0;
+	uint32 topoCount = 0;
+	get_cpu_topology_info(NULL, &topoCount);
+	if (topoCount > 0) {
+		cpu_topology_node_info topology[topoCount];
+		get_cpu_topology_info(topology, &topoCount);
+		for (int i = 0; i < topoCount; ++i) {
+			if (topology[i].type == B_TOPOLOGY_CORE)
+				fSystemClockSpeed += topology[i].data.core.default_frequency;
+		}
+	} else {
+		// fall back to cpu info; note that current_frequency
+		// is dynamic and could be less than the cpu speed
+		cpu_info cpuInfos[fCpuCount];
+		get_cpu_info(0, fCpuCount, cpuInfos);
+		for (int i = 0; i < fCpuCount; ++i)
+			fSystemClockSpeed += cpuInfos[i].current_frequency;
+	}
+}
+
 BBitmap*
 Manipulator::DuplicateBitmap(BBitmap* source, int32 inset, bool acceptViews)
 {

--- a/artpaint/viewmanipulators/Manipulator.h
+++ b/artpaint/viewmanipulators/Manipulator.h
@@ -50,7 +50,7 @@ class Manipulator {
 	friend class ManipulatorServer;
 
 public:
-									Manipulator() { add_on_id = -1; }
+									Manipulator();
 	virtual							~Manipulator() {}
 
 	virtual	BBitmap*				ManipulateBitmap(BBitmap*, Selection*,
@@ -58,6 +58,10 @@ public:
 	virtual	ManipulatorSettings*	ReturnSettings() { return NULL; }
 	virtual	const char*				ReturnName() = 0;
 
+	double							GetSystemClockSpeed()
+										{ return fSystemClockSpeed; }
+	int								GetSystemCpuCount()
+										{ return fCpuCount; }
 protected:
 			BBitmap*				DuplicateBitmap(BBitmap* source,
 										int32 inset = 0,
@@ -65,6 +69,8 @@ protected:
 
 private:
 			image_id				add_on_id;
+			double					fSystemClockSpeed;
+			int						fCpuCount;
 };
 
 #endif	// MANIPULATOR_H

--- a/artpaint/viewmanipulators/RotationManipulator.cpp
+++ b/artpaint/viewmanipulators/RotationManipulator.cpp
@@ -17,14 +17,14 @@
 #include <TextControl.h>
 #include <Window.h>
 
-#include "MessageConstants.h"
-#include "RotationManipulator.h"
-#include "ImageView.h"
-#include "PixelOperations.h"
-#include "Selection.h"
+
 #include "HSPolygon.h"
+#include "ImageView.h"
+#include "MessageConstants.h"
+#include "PixelOperations.h"
+#include "RotationManipulator.h"
+#include "Selection.h"
 #include "StringServer.h"
-#include "SysInfoBeOS.h"
 
 
 #define PI M_PI
@@ -106,11 +106,7 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 	}
 
 	if (preview_bitmap != NULL) {
-		// Use a custom header to get the legacy system_info with cpu speed
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-		speed = speed / 15000;
+		double speed = GetSystemClockSpeed() / 15000;
 
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
@@ -127,6 +123,7 @@ void RotationManipulator::SetPreviewBitmap(BBitmap *bitmap)
 	last_calculated_resolution = lowest_available_quality;
 }
 
+
 BRegion RotationManipulator::Draw(BView *view,float mag_scale)
 {
 	float x = settings->origo.x;
@@ -140,7 +137,6 @@ BRegion RotationManipulator::Draw(BView *view,float mag_scale)
 	updated_region.Set(BRect(mag_scale*x-10,mag_scale*y-10,mag_scale*x+10,mag_scale*y+10));
 	return updated_region;
 }
-
 
 
 void RotationManipulator::MouseDown(BPoint point,uint32 buttons,BView*,bool first_click)
@@ -249,7 +245,6 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 
 	uint32 p1,p2,p3,p4;
 
-
 	union {
 		uint8	bytes[4];
 		uint32	word;
@@ -259,7 +254,6 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 	background.bytes[1] = 0xFF;
 	background.bytes[2] = 0xFF;
 	background.bytes[3] = 0x00;
-
 
 	if (selection->IsEmpty()) {
 		for (float y=0;y<=height;y++) {
@@ -434,6 +428,7 @@ BBitmap* RotationManipulator::ManipulateBitmap(ManipulatorSettings *set,BBitmap 
 
 	return new_bitmap;
 }
+
 
 int32 RotationManipulator::PreviewBitmap(Selection *selection,bool full_quality,BRegion *updated_region)
 {

--- a/artpaint/viewmanipulators/TranslationManipulator.cpp
+++ b/artpaint/viewmanipulators/TranslationManipulator.cpp
@@ -17,11 +17,10 @@
 
 #include "ImageView.h"
 #include "MessageConstants.h"
-#include "Selection.h"
-#include "TranslationManipulator.h"
-#include "StringServer.h"
 #include "NumberControl.h"
-#include "SysInfoBeOS.h"
+#include "Selection.h"
+#include "StringServer.h"
+#include "TranslationManipulator.h"
 
 
 using ArtPaint::Interface::NumberControl;
@@ -407,15 +406,12 @@ void TranslationManipulator::SetPreviewBitmap(BBitmap *bm)
 	}
 
 	if (preview_bitmap != NULL) {
-		// Use a custom header to get the legacy system_info with cpu speed
-		BeOS_system_info info;
-		get_BeOS_system_info(&info);
-		double speed = info.cpu_count * info.cpu_clock_speed;
-		speed = speed / 1000;
+		double speed = GetSystemClockSpeed() / 1000;
 
 		BRect bounds = preview_bitmap->Bounds();
 		float num_pixels = (bounds.Width()+1) * (bounds.Height() + 1);
 		lowest_available_quality = 1;
+
 		while ((2*num_pixels/lowest_available_quality/lowest_available_quality) > speed)
 			lowest_available_quality *= 2;
 


### PR DESCRIPTION
…call. (#82)

Removed reliance on "get_BeOS_system_info" and use newer "get_system_info"
call plus "get_cpu_topology_info" to get the CPU clock speeds. If topologies
are not found, fall back to "get_cpu_info" even though it might not be
accurate. Refactored calls into Manipulator base class so it's only called
once per Manipulator creation.

Also removed "round" function that conflicts with std::round, and
updated call to "ImportBits" to use the public API instead of a
private one.